### PR TITLE
ci: upgrade npm before publish to fix Trusted Publishing 404

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,10 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
+      # Node 20 ships npm 10.x; Trusted Publishers (OIDC -> registry auth)
+      # requires npm >= 11.5.1. Without this, --provenance signs via Sigstore
+      # but the registry PUT falls back to anonymous and 404s.
+      - run: npm install -g npm@latest
       - run: npm ci
 
       - name: Read version from package.json


### PR DESCRIPTION
## Problem

The first real run of the `release` workflow (added in #5) failed at the `Publish to npm (OIDC + provenance)` step with:

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1511991113
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/batch-upgrade-npm-packages - Not found
npm error 404  'batch-upgrade-npm-packages@2.0.0' is not in this registry.
```

The dry-run path works fine because it skips the actual `npm publish`.

## Root cause

The two halves of OIDC publishing happen in different places:

1. **Provenance signing** — happens via Sigstore. Only needs `id-token: write` and the GitHub OIDC token. Works on any recent npm CLI. The log confirms this succeeded (provenance was signed and pushed to the transparency log).
2. **Registry authentication** — npm has to exchange the OIDC token for an npm auth credential against the configured Trusted Publisher on `npmjs.org`. This second exchange was added in **npm 11.5.1**.

`actions/setup-node@v4` with `node-version: '20'` installs the npm CLI bundled with Node 20 LTS — **npm 10.x**. That version knows how to sign provenance but does **not** know how to perform the OIDC → registry auth exchange. With no `NODE_AUTH_TOKEN` and no Trusted Publisher exchange, the PUT goes out unauthenticated and the registry responds 404 (its way of saying "you can't see/touch this package as an anonymous client").

Not a propagation issue — Trusted Publisher config on npmjs.org takes effect immediately.

## Fix

Install the latest npm globally right after `setup-node`, before `npm ci` / `npm publish`:

```yaml
- run: npm install -g npm@latest
```

This pins the publish-time npm to a version that supports Trusted Publishers regardless of which npm Node 20 happens to bundle.

## Test plan

- [x] Run `release` workflow with `dry_run: true` — confirm preflight still passes (no regression in the verification path).
- [x] Run `release` workflow with `dry_run: false` — confirm `npm publish --provenance --access public` succeeds, tag is pushed, and GitHub release is created.
- [x] Verify the published tarball on npmjs.org shows the provenance badge.

## Notes

- The `verify` job intentionally does not get this step; it only lints/tests, never publishes.
- Once Node 22+ ships with npm 11.5.1+ by default, this step can be removed — but pinning explicitly is harmless and decouples CI behavior from whichever npm Node currently bundles.